### PR TITLE
[#5] Feat: Add WebSocket Connection With Rider

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/project/hotdealicious/common/config/RedisGeoConfig.java
+++ b/src/main/java/project/hotdealicious/common/config/RedisGeoConfig.java
@@ -1,9 +1,9 @@
 package project.hotdealicious.common.config;
 
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -29,12 +29,13 @@ public class RedisGeoConfig {
 	private Integer port;
 
 	@Bean
+	@Primary
 	public RedisConnectionFactory redisGeoConnectionFactory() {
 		return new LettuceConnectionFactory(host, port);
 	}
 
 	@Bean
-	@Qualifier("redisGeoTemplate")
+	@Primary
 	public RedisTemplate<String, Object> redisGeoTemplate() {
 		RedisTemplate<String, Object> redisGeoTemplate = new RedisTemplate<>();
 		redisGeoTemplate.setConnectionFactory(redisGeoConnectionFactory());

--- a/src/main/java/project/hotdealicious/common/config/RedisGeoConfig.java
+++ b/src/main/java/project/hotdealicious/common/config/RedisGeoConfig.java
@@ -1,0 +1,46 @@
+package project.hotdealicious.common.config;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
+
+@Configuration
+@EnableRedisHttpSession
+public class RedisGeoConfig {
+
+	/**
+	 * Geo Data는 라이더 클라이언트로부터 WebSocket 서버에 지속적으로 전송되는 데이터이다.
+	 * Redis Routing Table을 사용하여 분산 환경에서도 특정 WebSocket 서버와 라이더가 연결될 수 있는 환경이다.
+	 * In-Memory 특징을 살려 라이더 클라이언트로부터 Geo 데이터를 전송받으면 별도의 네트워크 처리 없이 해당 WebSocket 서버에 메모리 저장소로
+	 * 저장하는 것이 좋다고 생각되어 서버와 함께 실행된다.
+	 */
+
+	@Value("${spring.redis.host}")
+	private String host;
+
+	@Value("${spring.redis.port}")
+	private Integer port;
+
+	@Bean
+	public RedisConnectionFactory redisGeoConnectionFactory() {
+		return new LettuceConnectionFactory(host, port);
+	}
+
+	@Bean
+	@Qualifier("redisGeoTemplate")
+	public RedisTemplate<String, Object> redisGeoTemplate() {
+		RedisTemplate<String, Object> redisGeoTemplate = new RedisTemplate<>();
+		redisGeoTemplate.setConnectionFactory(redisGeoConnectionFactory());
+		redisGeoTemplate.setKeySerializer(new StringRedisSerializer());
+		redisGeoTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+		return redisGeoTemplate;
+	}
+}

--- a/src/main/java/project/hotdealicious/common/config/RedisRoutingTableConfig.java
+++ b/src/main/java/project/hotdealicious/common/config/RedisRoutingTableConfig.java
@@ -1,0 +1,46 @@
+package project.hotdealicious.common.config;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
+
+@Configuration
+@EnableRedisHttpSession
+public class RedisRoutingTableConfig {
+
+	/**
+	 * Redis Routing Table은 특정 WebSocket 서버와 라이더 클라이언트 간의 연결을 지속시키기 위해 사용한다.
+	 * Redis Routing Table은 별개의 서버에서 webSocket 클라이언트로부터 요청받아 URI가 있으면 바로 다이렉트로
+	 * WebSocket 서버로 요청할 것이고, 만약 URI가 없다면 HA Proxy같은 로드벨런서를 통해 적절한 WebSocket 서버와 연결한 후 요청할 것이다.
+	 *
+	 * Redis Routing Table도 서버 어플리케이션과는 별개의 서버에서 구동하여 클라이언트로부터 요청을 받아야하지만, 현재 PC가 하나뿐이므로 port 번호를
+	 * 변경하는 것으로 마무리한다.
+	 */
+
+	@Value("${spring.redis.host}")
+	private String host;
+
+	private final Integer port = 6370;
+
+	@Bean
+	public RedisConnectionFactory redisRoutingTableConnectionFactory() {
+		return new LettuceConnectionFactory(host, port);
+	}
+
+	@Bean
+	@Qualifier("redisRoutingTableTemplate")
+	public RedisTemplate<String, String> redisRoutingTableTemplate() {
+		RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+		redisTemplate.setConnectionFactory(redisRoutingTableConnectionFactory());
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+		return redisTemplate;
+	}
+}

--- a/src/main/java/project/hotdealicious/common/config/RedisSessionConfig.java
+++ b/src/main/java/project/hotdealicious/common/config/RedisSessionConfig.java
@@ -9,13 +9,19 @@ import org.springframework.session.data.redis.config.annotation.web.http.EnableR
 
 @Configuration
 @EnableRedisHttpSession
-public class RedisConfig {
+public class RedisSessionConfig {
+
+	/**
+	 * Redis Session은 분산 환경에서 특정 회원의 로그인 관리를 하기 위해 사용했다.
+	 * 그렇기 때문에 Redis Session은 서버 어플리케이션과는 별개의 서버에서 실행되어져야 한다.
+	 * 지금은 하나의 PC에서 실행하기 때문에 포트번호만 다르지만, 이후 이 Redis Session을 실행하고 있는
+	 * 별도의 host를 부여해야한다.
+	 */
 
 	@Value("${spring.redis.host}")
 	private String host;
 
-	@Value("${spring.redis.port}")
-	private Integer port;
+	private Integer port = 6371;
 
 	@Bean
 	public RedisConnectionFactory redisConnectionFactory() {

--- a/src/main/java/project/hotdealicious/common/config/WebSocketConfigurer.java
+++ b/src/main/java/project/hotdealicious/common/config/WebSocketConfigurer.java
@@ -1,0 +1,23 @@
+package project.hotdealicious.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfigurer implements WebSocketMessageBrokerConfigurer {
+
+	@Override
+	public void configureMessageBroker(MessageBrokerRegistry registry) {
+		registry.setApplicationDestinationPrefixes("/rider");
+	}
+
+	@Override
+	public void registerStompEndpoints(StompEndpointRegistry registry) {
+		registry.addEndpoint("/ws")
+			.setAllowedOrigins("*");
+	}
+}

--- a/src/main/java/project/hotdealicious/rider/domain/WorkStatus.java
+++ b/src/main/java/project/hotdealicious/rider/domain/WorkStatus.java
@@ -3,7 +3,7 @@ package project.hotdealicious.rider.domain;
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 public enum WorkStatus {
-	OFFLINE, ONLINE;
+	INIT, WAIT, PROCESS, COMPLETE;
 
 	@JsonCreator
 	public static WorkStatus from(String s) {

--- a/src/main/java/project/hotdealicious/rider/dto/GeoLocation.java
+++ b/src/main/java/project/hotdealicious/rider/dto/GeoLocation.java
@@ -1,0 +1,14 @@
+package project.hotdealicious.rider.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class GeoLocation {
+
+	private double x;
+	private double y;
+}

--- a/src/main/java/project/hotdealicious/rider/dto/RiderGeoDto.java
+++ b/src/main/java/project/hotdealicious/rider/dto/RiderGeoDto.java
@@ -1,0 +1,24 @@
+package project.hotdealicious.rider.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import project.hotdealicious.rider.domain.WorkStatus;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class RiderGeoDto {
+
+	private WorkStatus workStatus;
+	private String sender;
+	private Long riderId;
+	private GeoLocation data;
+
+	public void setSender(String sender) {
+		this.sender = sender;
+	}
+
+}

--- a/src/main/java/project/hotdealicious/rider/web/RiderProfileController.java
+++ b/src/main/java/project/hotdealicious/rider/web/RiderProfileController.java
@@ -1,7 +1,11 @@
 package project.hotdealicious.rider.web;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 
+import org.springframework.data.geo.Point;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -11,9 +15,10 @@ import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
 import project.hotdealicious.common.util.basewrapper.ApiResult;
+import project.hotdealicious.rider.domain.WorkStatus;
+import project.hotdealicious.rider.dto.RiderGeoDto;
 import project.hotdealicious.rider.dto.SaveRiderDto;
 import project.hotdealicious.rider.dto.UpdateRiderDto;
-import project.hotdealicious.rider.dto.UpdateWorkStatusDto;
 import project.hotdealicious.rider.service.RiderProfileService;
 
 @RestController
@@ -22,6 +27,8 @@ import project.hotdealicious.rider.service.RiderProfileService;
 public class RiderProfileController {
 
 	private final RiderProfileService riderProfileService;
+	private final RedisTemplate<String, Object> redisGeoTemplate;
+	private final RedisTemplate<String, String> redisRoutingTableTemplate;
 
 	@PostMapping
 	public ApiResult<Long> join(@Valid @RequestBody SaveRiderDto saveRiderDto) {
@@ -35,15 +42,33 @@ public class RiderProfileController {
 		return ApiResult.onSuccess(riderId);
 	}
 
-	@PostMapping("/commute/{id}")
-	public ApiResult<Long> checkCommute(@PathVariable Long id, @RequestBody UpdateWorkStatusDto updateWorkStatusDto) {
-		Long riderId = riderProfileService.updateWorkStatus(id, updateWorkStatusDto.getWorkStatus());
-		return ApiResult.onSuccess(riderId);
-	}
-
 	@DeleteMapping("/{id}")
 	public ApiResult<Long> withdrawRider(@PathVariable Long id) {
 		Long riderId = riderProfileService.withdraw(id);
 		return ApiResult.onSuccess(riderId);
+	}
+
+	@MessageMapping("/commute")
+	public ApiResult<Long> checkCommute(RiderGeoDto riderGeoDto, HttpServletRequest request) {
+		Point point = new Point(riderGeoDto.getData().getX(), riderGeoDto.getData().getY());
+		redisGeoTemplate.opsForGeo().add("myMap", point, riderGeoDto.getRiderId());
+
+		if (riderGeoDto.getWorkStatus() == WorkStatus.INIT) {
+			connectWebSocketServerToRider(riderGeoDto.getRiderId(), request);
+		}
+
+		return ApiResult.onSuccess(riderGeoDto.getRiderId());
+	}
+
+	private void connectWebSocketServerToRider(@PathVariable Long id, HttpServletRequest request) {
+		redisRoutingTableTemplate.opsForValue().set(String.valueOf(id), makeUri(request));
+	}
+
+	private String makeUri(HttpServletRequest request) {
+		String scheme = request.getScheme();
+		String host = request.getServerName();
+		int remotePort = request.getServerPort();
+
+		return scheme.concat("://").concat(host).concat(":").concat(String.valueOf(remotePort));
 	}
 }

--- a/src/main/java/project/hotdealicious/rider/web/WebSocketRoutingTableController.java
+++ b/src/main/java/project/hotdealicious/rider/web/WebSocketRoutingTableController.java
@@ -1,0 +1,32 @@
+package project.hotdealicious.rider.web;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import project.hotdealicious.common.util.basewrapper.ApiResult;
+
+/**
+ * Redis Routing Table이 있는 서버에서 실행되는 API
+ * 메인 서버 어플리케이션에서 실행되지 않는다. (단, 여기에서는 프로젝트이기 때문에 하나의 서버로 동작한다.)
+ */
+
+@RestController
+@RequestMapping("/api/v1/rider")
+@RequiredArgsConstructor
+public class WebSocketRoutingTableController {
+
+	private final RedisTemplate<String, String> redisRoutingTableTemplate;
+
+	@GetMapping("/{id}")
+	public ApiResult<String> getConnectedWebSocketUri(@PathVariable String id, HttpServletRequest request) {
+		String str = redisRoutingTableTemplate.opsForValue().get(id);
+
+		return ApiResult.onSuccess(str);
+	}
+}


### PR DESCRIPTION
![4D5C2FF7-9DCF-4033-9BA1-742F4BD93F64](https://github.com/f-lab-edu/Hot-Dealicious/assets/71717303/d32d2190-1095-4603-ac88-05f56be2f22c)

현재 이렇게 설계하여 WebSocket 통신을 구현해보았습니다!

- Redis를 각 사용 목적에 맞게 분산하여 별도의 서버에서 처리하도록 하였습니다.
  - Redis Session 같은 경우 분산 서버 환경에서 회원의 로그인 관리를 해야하기 때문에 별개의 서버에서 실행해야한다고 생각했습니다.
  - Redis Routing Table도 마찬가지로 클라이언트가 먼저 WebSocket 통신을 시작하기 위해서는 먼저 Routing Table이 있는 서버에 진입한 후 라이더와 WebSocket 서버와의 커넥션 유무를 확인해야한다고 생각했습니다. 특정 서버에 종속되어 있는것이 아닌 별개의 서버에서 관리하여 분산 환경에서 처리하도록 하는 것이 맞다고 판단했습니다.

❗️ 위 Redis의 2가지 경우 모두 WebSocket 서버가 아닌 별개의 서버에서 처리해야하지만, 프로젝트이기 때문에 하나의 Repo안에 저장하고 위의 상황은 가정으로만 두려고 합니다.

- Redis Geo 저장소는 In-Memory의 특성을 최대한 살리고 싶었습니다. 때문에 어차피 라이더 클라이언트와 WebSocket 서버는 Routing Table로 연결을 지속시킬 수 있을 것 같아 라이터의 위치 정보는 WebSocket 서버 어플리케이션이 실행되는 memory에서 Redis가 실행되는 것이 좋지 않을까 생각했습니다.
